### PR TITLE
Signed

### DIFF
--- a/_data/signed/CarlosGS.yaml
+++ b/_data/signed/CarlosGS.yaml
@@ -1,0 +1,2 @@
+name: Carlos Garcia
+link: https://github.com/CarlosGS


### PR DESCRIPTION
The statements in (https://rms-open-letter.github.io) are deliberately misleading and misinformative. Also, in the repository they are actively removing any opposing views, by closing relevant issues (https://github.com/rms-open-letter/rms-open-letter.github.io/issues/401), or even deleting them entirely (https://github.com/rms-open-letter/rms-open-letter.github.io/issues/666), flagging comments as irrelevant so they don't show up, etc. That is no way to present an 'open' letter - in fact it points to a directed strategy against RMS.

Hence I sign this new SUPPORT letter: "We urge the FSF to consider the arguments against RMS objectively and to truly understand the meaning of his words and actions."