### PR TITLE
fix typo in Xord8664

### DIFF
--- a/_data/signed/Xord8664.yaml
+++ b/_data/signed/Xord8664.yaml
@@ -1,2 +1,2 @@
 name: Dmitry Yushin
-site: https://github.com/Xord8664
+link: https://github.com/Xord8664


### PR DESCRIPTION
<!--
### Don't edit index.md directly!

### To sign, create a file in `_data/signed/` named `<username>.yaml` with the following content:

```yaml
name: <your name here>
link: <link to your profile or site>
```

### Example

```yaml
name: Richard Matthew Stallman
link: https://stallman.org/
```

Optional stuff you should consider:
- Use your real name if possible
- Add affiliated organizations or projects if applicable (e.g. `John Smith (Free Software Foundation, Popular Window Manager Author)`
-->

Xord8664 sign - fix typo