### PR TITLE
Signed by Ruslan Remenkov

### DIFF
--- a/_data/signed/remenkoff.yaml
+++ b/_data/signed/remenkoff.yaml
@@ -1,0 +1,2 @@
+name: Ruslan Remenkov
+link: https://github.com/remenkoff


### PR DESCRIPTION
Signature by Ruslan Remenkov of letter in support of Richard Matthew Stallman being reinstated by the Free Software Foundation.