### PR TITLE
fix link url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # An open letter in support of RMS.
 
+Optional for *nix users, before add sign can add pre-commit hook, for validated sign:
+
+```sh
+$ cp ./pre-commit .git/hooks/pre-commit
+```
+
 To sign, create a file in `_data/signed/` folder named `<username>.yaml` with the following content:
 
 ```yaml

--- a/_data/signed/moeryomenko.yaml
+++ b/_data/signed/moeryomenko.yaml
@@ -1,2 +1,2 @@
 name: Maxim Eryomenko
-link: https:/github.com/moeryomenko
+link: https://github.com/moeryomenko

--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+function is_valid_url {
+	regex='https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)'
+	if [[ $1 =~ $regex ]]
+	then
+		exit 0
+	else
+		echo ${BASH_REMATCH[@]}
+		exit 1
+	fi
+}
+
+
+function parse_yaml {
+   local prefix=$2
+   local s='[[:space:]]*' w='[a-zA-Z0-9_]*' fs=$(echo @|tr @ '\034')
+   sed -ne "s|^\($s\):|\1|" \
+        -e "s|^\($s\)\($w\)$s:$s[\"']\(.*\)[\"']$s\$|\1$fs\2$fs\3|p" \
+        -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  $1 |
+   awk -F$fs '{
+      indent = length($1)/2;
+      vname[indent] = $2;
+      for (i in vname) {if (i > indent) {delete vname[i]}}
+      if (length($3) > 0) {
+         vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
+         printf("%s%s%s=\"%s\"\n", "'$prefix'",vn, $2, $3);
+      }
+   }'
+}
+
+sign_file=`git diff --cached --name-only --diff-filter=AM _data/signed/`
+
+if [[ -n $sign_file ]]
+then
+	eval `parse_yaml $sign_file`
+	is_valid_url $link
+fi


### PR DESCRIPTION
add pre-commit hook for validate links.

the previous [pull request](https://github.com/rms-support-letter/rms-support-letter.github.io/pull/1771) made a mistake in the link.

Signed-off-by: Maxim Eryomenko <moeryomenko@gmail.com>

<!--
### Don't edit index.md directly!

### To sign, create a file in `_data/signed/` named `<username>.yaml` with the following content:

```yaml
name: <your name here>
link: <link to your profile or site>
```

### Example

```yaml
name: Richard Matthew Stallman
link: https://stallman.org/
```

Optional stuff you should consider:
- Use your real name if possible
- Add affiliated organizations or projects if applicable (e.g. `John Smith (Free Software Foundation, Popular Window Manager Author)`
-->
