### PR TITLE
Signed

### DIFF
--- a/_data/signed/drzrraf
+++ b/_data/signed/drzrraf
@@ -1,0 +1,2 @@
+name: Raf D
+link: https://github.com/drzraf


### PR DESCRIPTION
So happy to finally see an opportunity to see which FLOSS projects were already sponsored/subverted by USA Big Corp'.

_Mozilla_, _Gnome_ or _Creative Commons_ coming to the quarry is no surprise. _Debian_, _GNU Radio_ & _X.org_ : Definitely a deception but also the confirmation that organizations of techies are sometimes no better than activists funds or rotten lawyers. They take a stance based on the notoriety granted by fellow developers' work who mostly disagree: What a dirty and monopolistic use of a project brand.
... and _Tor Project_ taking a stance in favor of censorship and opinion condemnation is March 2021 best joke.

Let them 10 years and these same servile guys, pressured by their underlying financial sponsors, would relicense our worldwide GPL code bases under a GPLv4 _"This software is free software. You can use if you think the following way..."_.

Go RMS ! You stood against corporate capitalism owning our tech. Its newest XXI proxy is no different. Good collective structures get only subverted by military minorities (and their manipulated pseudomass) as long as the coward majority let them act silently.