### PR TITLE
Create Zipdox.yaml

### DIFF
--- a/_data/signed/Zipdox.yaml
+++ b/_data/signed/Zipdox.yaml
@@ -1,0 +1,2 @@
+name: Zipdox
+link: https://github.com/Zipdox


### PR DESCRIPTION
RMS is an integral component of the FSF, anyone that tries to remove him is undermining the software freedoms of people worldwide.