### PR TITLE
Add link to Tagalog translation

### DIFF
--- a/_layouts/signed.html
+++ b/_layouts/signed.html
@@ -23,6 +23,7 @@ layout: home
   <a class="translation" href='/index_ua.html'>🇺🇦</a>
   <a class="translation" href='/index_id.html'>🇮🇩</a>
   <a class="translation" href="/index_rs.html">🇷🇸</a>
+  <a class="translation" href="/index_tl.html">🇵🇭</a>
 </div>
 
 {{ content }}

--- a/_layouts/signed_rtl.html
+++ b/_layouts/signed_rtl.html
@@ -22,6 +22,7 @@ layout: home
   <a class="translation" href='/index_ua.html'>🇺🇦</a>
   <a class="translation" href='/index_id.html'>🇮🇩</a>
   <a class="translation" href="/index_rs.html">🇷🇸</a>
+  <a class="translation" href="/index_tl.html">🇵🇭</a>
 </div>
 
 <div style="direction: rtl">


### PR DESCRIPTION
The Tagalog translation works, but it currently can't be found in the webpage. This PR fixes that.