### PR TITLE
Add link to Vietnamese translation in right-to-left page

### DIFF
--- a/_layouts/signed_rtl.html
+++ b/_layouts/signed_rtl.html
@@ -7,6 +7,7 @@ layout: home
 <div class="translations">
   <p>Translations:</p>
   <a class="translation" href='/'>🇺🇸</a>
+  <a class="translation" href='/index_vi.html'>🇻🇳</a>
   <a class="translation" href='/index_zh_cn.html'>🇨🇳</a>
   <a class="translation" href='/index_tr.html'>🇹🇷</a>
   <a class="translation" href='/index_ro.html'>🇷🇴</a>


### PR DESCRIPTION
signed_rtl.html is missing a link to the Vietnamese translation.