### PR TITLE
Add link to the Dutch translation to translations.html

### DIFF
--- a/_includes/translations.html
+++ b/_includes/translations.html
@@ -9,6 +9,7 @@
   <a class="translation" href='/index_pt_pt.html'>🇵🇹</a>
   <a class="translation" href='/index_pt_br.html'>🇧🇷</a>
   <a class="translation" href='/index_de.html'>🇩🇪</a>
+  <a class="translation" href="/index_nl.html">🇳🇱</a>
   <a class="translation" href='/index_fr.html'>🇫🇷</a>
   <a class="translation" href='/index_pl.html'>🇵🇱</a>
   <a class="translation" href='/index_it.html'>🇮🇹</a>


### PR DESCRIPTION
I added the Dutch translation in #2697 but I noticed too late that the links were moved to translations.html so I forgot to add it. I have added it in this commit.