### PR TITLE
Improve translations block style

### DIFF
--- a/_includes/translations.html
+++ b/_includes/translations.html
@@ -8,8 +8,5 @@
       {%- assign c2 = langcode | slice: 1, 1 -%}
       {{- site.data.emoji[c1] -}}{{- site.data.emoji[c2] -}}
     </a>
-    {% if forloop.index == 11 %}
-      <br>
-    {% endif %}
   {% endfor %}
 </div>

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -5,9 +5,22 @@
 
 .translations {
 	text-align: end;
+	margin: 0 0 1em 0;
+}
+
+@media screen and (min-width: 800px) {
+	.translations {
+		width: 50%;
+		margin: 0 0 1em auto;
+	}
+}
+
+.translations p {
+	margin: 0 0 0.5em 0;
 }
 
 .translation {
+	line-height: 0.8em;
 	font-family: "Noto Color Emoji", sans-serif;
 	font-size: 2em;
 }


### PR DESCRIPTION
This patch removes manual `<br>` insert after 11 flags, which fixes layout on mobile devices.

It also applies 50% width limit on medium and large screens (similarly to how it looks now in non-mobile browsers) and improves paddings.

P.S. With current 11-flags-delimeter they may be displayed like this on mobile devices (or even worse):

```
XXXXXXXXX
       XX
     XXXX
```