### PR TITLE
Create 637man.yaml

### DIFF
--- a/_data/signed/637man.yaml
+++ b/_data/signed/637man.yaml
@@ -1,0 +1,2 @@
+name: Johannes Getmann
+link: https://github.com/637man


### PR DESCRIPTION
Adding my signature.

Being from the former Eastern Bloc, I cannot unsee similarities with quite recent history in this part of the world, and overall beginnings of totalitarianism. Furthermore, as a mild Asperger, characteristics of which Stallman may seem to exhibit, I am also concerned about being canceled a few years later for my past less-thought-out expressions.

Stallman's strife towards cybernetic freedom has been a great inspiration me ever since early childhood, interweaving with my fascination with cyberpunk, leading me to always try to convince other people to discontinue their use of popular proprietary software. Simply being "misogynist, ableist, or transphobic" as said in the other open letter doesn't warrant his removal, as it is mere labeling that has nothing to to with Free Software. Stallman's achievements greatly outweigh any of his personality quirks his opponents perceive. If anything, it suggests there are corpos behind this mob, who benefit from the stripped-down subversion called Open Source.
