### PR TITLE
Improve signatures enumeration and order

### DIFF
--- a/_includes/signatures.html
+++ b/_includes/signatures.html
@@ -1,16 +1,29 @@
 <p><b>Signed:</b></p>
 <ol>
-{% capture signs %}
-  {% for sign_hash in site.data.signed %}
-    {% assign signature = sign_hash[1] %}
-    |{{signature.name | escape }}#{{signature.link | escape }}
-  {% endfor %}
-{% endcapture %}
-{% assign sorted_signs = signs | split: '|' | sort %}
-{% for signature in sorted_signs %}
-  {% assign sign_items = signature | split: '#' %}
-  {% if sign_items[0] and sign_items[1] %} 
-  <li><a href="{{ sign_items[1] | strip }}">{{ sign_items[0] | strip }}</a></li>
-  {% endif %} 
-{% endfor %}
+{%- capture signs -%}
+  {%- for sign_hash in site.data.signed -%}
+    {%- assign signature = sign_hash[1] -%}
+    {%- assign name = signature.name | strip -%}
+    {%- assign name_order = name | downcase -%}
+    {%- assign first_char = name_order | slice: 0 -%}
+    {%- assign first_number = first_char | plus: 0 | append: '' -%}
+    {%- if first_char == first_number -%}
+      {%- assign name_order = name_order | prepend: '~' -%}
+    {%- endif -%}
+    <array>{{ name_order | escape }}<field>
+    <field>{{ name | escape }}<field>
+    <field>{{ signature.link | strip | escape }}<field>
+  {%- endfor -%}
+{%- endcapture -%}
+{%- assign sorted_signs = signs | split: '<array>' | sort -%}
+{%- for signature in sorted_signs -%}
+  {%- assign sign_items = signature | split: '<field>' -%}
+  {%- if sign_items[2] and sign_items[4] -%}
+  {%- assign name = sign_items[2] -%}
+  {%- assign link = sign_items[4] -%}
+  {% comment %}Add whitespace{% endcomment %}
+  <li><a href="{{ link }}">{{ name }}</a></li>
+  {%- endif -%}
+{%- endfor -%}
+{% comment %}Add whitespace{% endcomment %}
 </ol>


### PR DESCRIPTION
This patch changes the following:

1. Changes the order of signers. Now ordering is case-insensitive, and names started with a number are placed below names started with a latin letter.
2. Improves code style and data sanitizing. Liquid language doesn't allow to generate arrays easily, so hacks required: the code "captures" generated string as a variable and then turns it into array. To achieve this, the generated string must have delimiters.
Previously, `|` and `#` characters were used as delimiters, but they are valid characters in HTML, and YAMLs may contain them. Instead, I introduced new delimiters: `<array>` for array (replaces `|`) and `<field>` for field (replaces `#`).
These separators have `<>` (valid HTML characters) intentionally: since all input data is escaped (using `escape` function), it won't contain any HTML characters.
Moreover, `<field>` delimiter is added at the both "sides" of data, so fields won't have additional whitespaces after `split`. This removes requirement to `strip` data before adding it to the page, but fields should be accessed by even indices now (2/4 instead of 1/2).
So instead of `|name#link…` this code generates `<array>name<field>whitespace<field>link<field>whitespace…`.
And then this string is splitted into array by `<array>`, which elements are splitted into fields by `<field>`. I hope @cmd410 will find this approach better.
3. Removes additional empty lines (about 5-6 between each entry, iirc) from generated HTML (`{% %}` are replaced with `{%- -%}`). This doesn't change the page look, only makes its HTML source cleaner.