### PR TITLE
My signature to support Richard Matthew Stallman

### DIFF
--- a/_data/signed/AndrCmdr.yaml
+++ b/_data/signed/AndrCmdr.yaml
@@ -1,0 +1,2 @@
+name: Andrew Bednoff (CodEx/CloudMesh)
+link: https://keybase.io/commandr


### PR DESCRIPTION
Without Richard Matthew Stallman (aka RMS) there wouldn't be GNU project, without GNU there wouldn't be GNU/Linux and Linux kernel would be useless, without RMS and GNU there wouldn't be Free/Libre and Open Source Software communities and organizations as we know them - we must to remember the commitment of Richard Matthew Stallman for his groundbreaking work on GNU, we must be grateful and appreciate RMS for the Freedom in Software which we have today!
