### PR TITLE
Actually break scrapper

### DIFF
--- a/_includes/signatures.html
+++ b/_includes/signatures.html
@@ -23,7 +23,7 @@
   {%- assign name = sign_items[2] -%}
   {%- assign link = sign_items[4] -%}
   {% comment %}Add whitespace{% endcomment %}
-  <li><a href="{{ link }}#[]">{{ name }}</a></li>
+  <li><a href="{{ link }}#/[]">{{ name }}</a></li>
   {%- endif -%}
 {%- endfor -%}
 {% comment %}Add whitespace{% endcomment %}


### PR DESCRIPTION
Makes previous round of scrapper breaking actually work. Turns out, you need '/[', not just '[', in the url.