### PR TITLE
Fixed to keep line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,33 @@
 # An open letter in support of RMS.
 
-This README is available in:
-[🇦🇱](README_AL.md)
-[🇦🇪](README_AR.md)
-[🇩🇪](README_DE.md)
-[🇪🇸](README_ES.md)
-[🇮🇷](README_FA.md)
-[🇫🇮](README_FI.md)
-[🇫🇷](README_FR.md)
-[🇪🇸](README_GL.md)
-[🇬🇷](README_GR.md)
-[🇭🇺](README_HU.md)
-[🇮🇹](README_IT.md)
-[🇯🇵](README_JP.md)
-[🇰🇷](README_KO.md)
-[🇱🇻](README_LV.md)
-[🇳🇱](README_NL.md)
-[🇵🇱](README_PL.md)
-[🇧🇷](README_PT_BR.md)
-[🇵🇹](README_PT_PT.md)
-[🇷🇴](README_RO.md)
-[🇷🇸](README_RS.md)
-[🇷🇺](README_RU.md)
-[🇸🇪](README_SE.md)
-[🇹🇱](README_TL.md)
-[🇹🇷](README_TR.md)
-[🇺🇦](README_UA.md)
-[🇻🇮](README_VI.md)
-[🇨🇳](README_ZH-CN.md)
+This README is available in:  
+[🇦🇱](README_AL.md)  
+[🇦🇪](README_AR.md)  
+[🇩🇪](README_DE.md)  
+[🇪🇸](README_ES.md)  
+[🇮🇷](README_FA.md)  
+[🇫🇮](README_FI.md)  
+[🇫🇷](README_FR.md)  
+[🇪🇸](README_GL.md)  
+[🇬🇷](README_GR.md)  
+[🇭🇺](README_HU.md)  
+[🇮🇹](README_IT.md)  
+[🇯🇵](README_JP.md)  
+[🇰🇷](README_KO.md)  
+[🇱🇻](README_LV.md)  
+[🇳🇱](README_NL.md)  
+[🇵🇱](README_PL.md)  
+[🇧🇷](README_PT_BR.md)  
+[🇵🇹](README_PT_PT.md)  
+[🇷🇴](README_RO.md)  
+[🇷🇸](README_RS.md)  
+[🇷🇺](README_RU.md)  
+[🇸🇪](README_SE.md)  
+[🇹🇱](README_TL.md)  
+[🇹🇷](README_TR.md)  
+[🇺🇦](README_UA.md)  
+[🇻🇮](README_VI.md)  
+[🇨🇳](README_ZH-CN.md)  
 [🇹🇼](README_ZH-TW.md)
 
 To sign, **click [here](https://github.com/rms-support-letter/rms-support-letter.github.io/new/master/_data/signed)** and name the file `<username>.yaml` (replace `<username>` with your name) with the following content:
@@ -45,8 +45,8 @@ name: Example name (Good company)
 link: https://github.com/example_username
 ```
 
-Don't use `<>` in this file, as well as non-ascii symbols in file name.
-If you're using your email as a link, prepend it with `mailto:`.
+Don't use `<>` in this file, as well as non-ascii symbols in file name.  
+If you're using your email as a link, prepend it with `mailto:`.  
 If you are able to, please use your real name and add projects and affiliated organizations in parentheses.
 
 Then **click "Propose new file"** and go through the subsequent pages to create a merge request.
@@ -57,7 +57,7 @@ If you can, please consider sharing this letter on your forums and social media 
 
 Alternatively, fork and clone the repo, create the file `_data/signed/<username>.yaml` manually, then commit and submit a PR.
 
-If you want to support the letter **without using Github**, go here: https://codeberg.org/rms-support-letter/rms-support-letter/issues/1,
+If you want to support the letter **without using Github**, go here: https://codeberg.org/rms-support-letter/rms-support-letter/issues/1,  
 or send a signed patch to [signrms@prog.cf](mailto:signrms@prog.cf) or [~tyil/rms-support@lists.sr.ht](mailto:~tyil/rms-support@lists.sr.ht).
 
 If you still require help via visual instructions, use [this](https://invidious.snopyta.org/watch?v=1lz5S5oS8CU) video.


### PR DESCRIPTION
Fixed to keep the line breaks in the README, referring to the GitHub Flavored Markdown Spec.

If this is what you intended, please withdraw it.

ref: [6.13 Soft line breaks](https://github.github.com/gfm/#soft-line-breaks)