### PR TITLE
Create ashneo76.yml

### DIFF
--- a/_data/signed/ashneo76.yaml
+++ b/_data/signed/ashneo76.yaml
@@ -1,0 +1,2 @@
+name: Ashish S (FSF Associate Member, since Feb 2020)
+link: https://github.com/ashneo76


### PR DESCRIPTION
Sign in support of RMS.

RMS is perfectly suited to be a _board_ member of FSF. This is not even a question of being a BDFL, but a board member, one of many. RMS has been pushing for Free software and Freedom for so long, that "cancelling" him is going to lead a significantly harmful and deadly blow to our personal and software freedoms. In an age, where these are under constant attack from the governments, greed corporations like Amazon, Google, FB, etc., the Free Software community cannot accept a loss of a visionary. 

This is outright bullying of RMS, if not worse. 