### PR TITLE
Bullies under disguise are still obvious

### DIFF
--- a/_data/signed/oelmekki.yaml
+++ b/_data/signed/oelmekki.yaml
@@ -1,0 +1,2 @@
+name: Olivier El Mekki (FSF contributor, made lot of minor/invisible freesoftwares or patches, see github)
+link: https://github.com/oelmekki


### PR DESCRIPTION
Normies are very sad they're not allowed anymore to be racists, sexists,
and many other aspects of hate, so they are targeting the next "weird"
guy. "There's no label on that one yet, right? Great! Bring the
stones!". Nope, you're still dicks.
