### PR TITLE
nb_NO translation

### DIFF
--- a/README_NB_NO.md
+++ b/README_NB_NO.md
@@ -1,0 +1,86 @@
+# Et åpent brev til støtte for RMS.
+
+Denne README-filen er tilgjengelig som:
+[🇿🇦](README_AF.md)
+[🇦🇱](README_AL.md)
+[🇦🇪](README_AR.md)
+[🇩🇪](README_DE.md)
+[🇪🇸](README_ES.md)
+[🇮🇷](README_FA.md)
+[🇫🇮](README_FI.md)
+[🇫🇷](README_FR.md)
+[🇪🇸](README_GL.md)
+[🇬🇷](README_GR.md)
+[🇭🇺](README_HU.md)
+[🇮🇹](README_IT.md)
+[🇯🇵](README_JP.md)
+[🇰🇷](README_KO.md)
+[🇱🇻](README_LV.md)
+[🇳🇴](README_NB_NO.md)
+[🇳🇱](README_NL.md)
+[🇵🇱](README_PL.md)
+[🇧🇷](README_PT_BR.md)
+[🇵🇹](README_PT_PT.md)
+[🇷🇴](README_RO.md)
+[🇷🇸](README_RS.md)
+[🇷🇺](README_RU.md)
+[🇸🇪](README_SE.md)
+[🇵🇭](README_TL.md)
+[🇹🇷](README_TR.md)
+[🇺🇦](README_UA.md)
+[🇻🇳](README_VI.md)
+[🇨🇳](README_ZH-CN.md)
+[🇹🇼](README_ZH-TW.md)
+
+Du signerer ved å **trykke [her](https://github.com/rms-support-letter/rms-support-letter.github.io/new/master/_data/signed)**, for så å navngi den nye filen `<brukernavn>.yaml`. Erstatt `<brukernavn>` med ditt navn, og legg til følgende innhold:
+
+```yaml
+navn: <ditt navn her (valgfri organisasjon, bedrift, eller foretagende)>
+lenke: <lenke til din profil eller side>
+```
+
+Altså, uten `<>`.
+
+Eksempel:
+```yaml
+navn: Ola Nordmann (bedrift/foretagende)
+lenke: https://github.com/eksempel_brukernavn
+```
+
+Ikke bruk `<>` i denne filen, og ellers kun ASCII-symboler i filnavnet. Hvis du bruker e-postadressen din som en lenke, kan du innlede den med `mailto:`. Har du muligheten bør du bruke ditt eget navn, og legge til prosjekter og tilknyttede organisasjoner i parentes.
+
+**Klikk så på "Propose new file"** (foreslå ny fil) og gå gjennom de påkrevde trinnene for å opprette din flettingsforespørsel.
+
+Hvis du kan, bør du overveie å dele dette brevet i dine fora og sosiale kanaler, samt å ta kontakt med objektive journalister.
+
+Alternativt kan du forgreine og klone kodelageret, for så å opprette filen `_data/signed/<username>.yaml` manuelt, og deretter sende inn en flettingsforespørsel.
+
+Hvis du ønsker å tilknytte deg brevet **uten å bruke GitHub**, kan du gjøre det her: https://codeberg.org/rms-support-letter/rms-support-letter/issues/1, eller sende en signert feilfiks til [signrms@prog.cf](mailto:signrms@prog.cf) eller [~tyil/rms-support@lists.sr.ht](mailto:~tyil/rms-support@lists.sr.ht).
+
+Hvis du vil ha ytterligere hjelp i visuell form, kan du ta en titt på [denne](https://invidious.snopyta.org/watch?v=1lz5S5oS8CU) videoen.
+
+### Har du endret mening og vil ha din underskrift fjernet fra brevet _mot_ Richard Stallman?
+Du kan la din intensjon komme til uttrykk her: https://github.com/rms-support-letter/revoke-open-letter-signature
+
+## Sludrerom
+
+- **Matrix:** [+free-rms:matrix.org](https://matrix.to/#/+free-rms:matrix.org)
+- **IRC:** #free-rms on [freenode](https://freenode.net) ([webchat](https://kiwiirc.com/client/irc.freenode.net/#free-rms)) (Jabber gateway : `#free-rms%chat.freenode.net@biboumi.marc-o.win` )
+- **XMPP/Jabber:** [support-rms@conf.marc-o.win](xmpp:support-rms@conf.marc-o.win?join)
+- **Discord:** <https://discord.gg/7FWkxG4CsU>
+- **Telegram:** <https://t.me/free_rms>
+- **GitHub-diskusjon:** <https://github.com/rms-support-letter/rms-support-letter.github.io/discussions>
+
+## Våre venner
+https://stallmansupport.org/
+
+## Kontakt
+Hvis du er fra pressen, eller representerer media av noen art, kan du kontakte oss på denne e-postadressen:
+- [rms-support-letter@protonmail.com](mailto:rms-support-letter@protonmail.com)
+
+## Lisensiering
+Koden i dette kodelageret er lisensiert [GPL-3.0-only](https://spdx.org/licenses/GPL-3.0-only.html).
+
+Bilder i`assets`-mappen er lisensiert [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/legalcode). Den sosiale forhåndsvisningen er basert på https://commons.wikimedia.org/wiki/File:Richard_Matthew_Stallman.jpeg, utgitt som CC BY-SA 3.0, opprinnelig publisert i form av omslaget på en O'Reilly-bok ved navn `Free as in Freedom: Richard Stallman's Crusade for Free Software by Sam Williams`, utgitt 1 mars, 2002 som GFDL.
+
+Signaturer kan ikke kopirettsbeskyttes.


### PR DESCRIPTION
It pains me to not remove Telegram and Discord.

Should be "GitHub" "Jabber" and "ASCII" in the original.

Added a link to the GPL-3.0-only license text.
Changed the text to ~"objective journalists".