### PR TITLE
Completely migrate from freenode to libera

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ You can show your intention here: https://github.com/rms-support-letter/revoke-o
 ## Chatrooms
 
 - **Matrix:** [+free-rms:matrix.org](https://matrix.to/#/+free-rms:matrix.org)
-- **IRC at libera:** #freerms on [libera](https://libera.chat) ([webchat](https://kiwiirc.com/client/irc.libera.chat/#freerms))
-- **Freenode:** #free-rms on [freenode](https://freenode.net) ([webchat](https://kiwiirc.com/client/irc.freenode.net/#free-rms), Jabber gateway: `#free-rms%chat.freenode.net@biboumi.marc-o.win`)
+- **IRC:** #freerms on [libera](https://libera.chat) ([webchat](https://kiwiirc.com/client/irc.libera.chat/#freerms))
 - **XMPP/jabber:** [support-rms@conf.marc-o.win](xmpp:support-rms@conf.marc-o.win?join)
 - **Discord:** <https://discord.gg/7FWkxG4CsU>
 - **Telegram:** <https://t.me/free_rms>

--- a/README_AF.md
+++ b/README_AF.md
@@ -34,7 +34,7 @@ As jy kan, oorweeg dit om díe brief in jou forums en sosiale media te versprei.
 ## Kletskamers
 
 - **Matrix:** [+free-rms:matrix.org](https://matrix.to/#/+free-rms:matrix.org)
-- **IRC:** #free-rms on [freenode](https://freenode.net) ([webchat](https://kiwiirc.com/client/irc.freenode.net/#free-rms)) (Jabber gateway : `#free-rms%chat.freenode.net@biboumi.marc-o.win` )
+- **IRC:** #freerms on [libera](https://libera.chat) ([webchat](https://kiwiirc.com/client/irc.libera.chat/#freerms))
 - **XMPP/jabber:** [support-rms@conf.marc-o.win](xmpp:support-rms@conf.marc-o.win?join)
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms

--- a/README_AL.md
+++ b/README_AL.md
@@ -32,7 +32,7 @@ Nëse përsëri ju duhet ndihmë nga ana vizuale, shikoni [videon](https://invid
 ## Chatrooms
 
 - **Matrix:** [+free-rms:matrix.org](https://matrix.to/#/+free-rms:matrix.org)
-- **IRC:** #free-rms on [freenode](https://freenode.net)
+- **IRC:** #freerms on [libera](https://libera.chat)
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms
 

--- a/README_AR.md
+++ b/README_AR.md
@@ -35,6 +35,6 @@ https://codeberg.org/rms-support-letter/rms-support-letter/issues/1,
 ## غرف دردشة
 
 - **Matrix.org:** #free-rms:matrix.org
-- **IRC:** #free-rms at chat.freenode.net
+- **IRC:** #freerms at irc.libera.chat
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms

--- a/README_DE.md
+++ b/README_DE.md
@@ -40,6 +40,6 @@ Falls du visuelle Hilfe benötigst, verwende [dieses](https://invidious.snopyta.
 ## Chaträume (Englisch)
 
 - **Matrix:** [+free-rms:matrix.org](https://matrix.to/#/+free-rms:matrix.org)
-- **IRC:** #free-rms auf [freenode](https://freenode.net)
+- **IRC:** #freerms auf [libera](https://libera.chat)
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms

--- a/README_ES.md
+++ b/README_ES.md
@@ -35,6 +35,6 @@ o envíe un parche firmado a [signrms@prog.cf](mailto:signrms@prog.cf) o [~tyil/
 ## Salas de chat
 
 - **Matrix.org:** #free-rms:matrix.org
-- **IRC:** #free-rms at chat.freenode.net
+- **IRC:** #freerms at irc.libera.chat
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms

--- a/README_FA.md
+++ b/README_FA.md
@@ -37,6 +37,6 @@ link: https://github.com/example_username
 ## چت‌روم‌ها
 
 - **Matrix:** [#free-rms:matrix.org](https://matrix.to/#/#free-rms:matrix.org)
-- **IRC:** #free-rms on [freenode](https://freenode.net)
+- **IRC:** #freerms on [libera](https://libera.chat)
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms

--- a/README_FI.md
+++ b/README_FI.md
@@ -66,7 +66,7 @@ Jos tarvitset tukea allekirjoittamiseen videon avulla, katso ohjevideo osoittees
 
 ## Keskusteluhuoneet
 - **Matrix:** [+free-rms:matrix.org](https://matrix.to/#/+free-rms:matrix.org)
-- **IRC:** #free-rms on [freenode](https://freenode.net)
+- **IRC:** #freerms on [libera](https://libera.chat)
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms
 

--- a/README_FR.md
+++ b/README_FR.md
@@ -35,7 +35,7 @@ Si vous avez encore besoin d'aide avec des instructions visuelles, utilisez [cet
 
 ## Chatrooms (en Anglais)
 - **Matrix.org:** [+free-rms:matrix.org](https://matrix.to/#/+free-rms:matrix.org)
-- **IRC:** #free-rms on [freenode](https://freenode.net) ([webchat](https://kiwiirc.com/client/irc.freenode.net/#free-rms)) (Jabber gateway : `#free-rms%chat.freenode.net@biboumi.marc-o.win` )
+- **IRC:** #freerms on [libera](https://libera.chat) ([webchat](https://kiwiirc.com/client/irc.libera.chat/#freerms))
 - **XMPP/jabber:** [support-rms@conf.marc-o.win](xmpp:support-rms@conf.marc-o.win?join)
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram**: https://t.me/free_rms

--- a/README_GL.md
+++ b/README_GL.md
@@ -35,6 +35,6 @@ ou envíe un parche asinado a [signrms@prog.cf](mailto:signrms@prog.cf) ou [~tyi
 ## Salas de chat
 
 - **Matrix.org:** #free-rms:matrix.org
-- **IRC:** #free-rms at chat.freenode.net
+- **IRC:** #freerms at irc.libera.chat
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms

--- a/README_GR.md
+++ b/README_GR.md
@@ -36,7 +36,7 @@ link: https://github.com/example_username
 ## Chatrooms
 
 - **Matrix:** [#free-rms:matrix.org](https://matrix.to/#/#free-rms:matrix.org)
-- **IRC:** #free-rms on [freenode](https://freenode.net)
+- **IRC:** #freerms on [libera](https://libera.chat)
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms
 

--- a/README_HU.md
+++ b/README_HU.md
@@ -53,7 +53,7 @@ nagy száma miatt**
 ## Chat szobák
 
 - **Matrix:** [+free-rms:matrix.org](https://matrix.to/#/+free-rms:matrix.org)
-- **IRC:** #free-rms on [freenode](https://freenode.net)
+- **IRC:** #freerms on [libera](https://libera.chat)
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms
 

--- a/README_HY.md
+++ b/README_HY.md
@@ -34,7 +34,7 @@ link: https://github.com/example_username
 ## Չաթելու տաղավարները:
 
 - **Matrix:** [+free-rms:matrix.org](https://matrix.to/#/+free-rms:matrix.org)
-- **IRC:** #free-rms on [freenode](https://freenode.net)
+- **IRC:** #freerms on [libera](https://libera.chat)
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms
 

--- a/README_IT.md
+++ b/README_IT.md
@@ -26,5 +26,5 @@ Se possibile, prendi in considerazione l'idea di condividere questa lettera su f
 ## Contatti
 
 - **Matrix.org:** #free-rms:matrix.org
-- **IRC:** #free-rms at chat.freenode.net
+- **IRC:** #freerms at irc.libera.chat
 - **Discord:** https://discord.gg/7FWkxG4CsU

--- a/README_JP.md
+++ b/README_JP.md
@@ -37,7 +37,7 @@ link: https://github.com/yamada_tarou
 ## チャットルーム
 
 - **Matrix:** [+free-rms:matrix.org](https://matrix.to/#/+free-rms:matrix.org)
-- **IRC:** #free-rms on [freenode](https://freenode.net)
+- **IRC:** #freerms on [libera](https://libera.chat)
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -36,7 +36,7 @@ link: https://example.com/
 ## 채팅방
 
 - **Matrix.org:** #free-rms:matrix.org
-- **IRC:** chat.freenode.net 서버의 #free-rms 채널
+- **IRC:** irc.libera.chat 서버의 #freerms 채널
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms
 

--- a/README_LV.md
+++ b/README_LV.md
@@ -36,6 +36,6 @@ vai sūtiet parakstīto patch uz [signrms@prog.cf](mailto:signrms@prog.cf) vai [
 ## Čata istabas
 
 - **Matrix.org:** #free-rms:matrix.org
-- **IRC:** #free-rms at chat.freenode.net
+- **IRC:** #freerms at irc.libera.chat
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms

--- a/README_NB_NO.md
+++ b/README_NB_NO.md
@@ -65,7 +65,7 @@ Du kan la din intensjon komme til uttrykk her: https://github.com/rms-support-le
 ## Sludrerom
 
 - **Matrix:** [+free-rms:matrix.org](https://matrix.to/#/+free-rms:matrix.org)
-- **IRC:** #free-rms on [freenode](https://freenode.net) ([webchat](https://kiwiirc.com/client/irc.freenode.net/#free-rms)) (Jabber gateway : `#free-rms%chat.freenode.net@biboumi.marc-o.win` )
+- **IRC:** #freerms on [libera](https://libera.chat) ([webchat](https://kiwiirc.com/client/irc.libera.chat/#freerms))
 - **XMPP/Jabber:** [support-rms@conf.marc-o.win](xmpp:support-rms@conf.marc-o.win?join)
 - **Discord:** <https://discord.gg/7FWkxG4CsU>
 - **Telegram:** <https://t.me/free_rms>

--- a/README_NL.md
+++ b/README_NL.md
@@ -37,6 +37,6 @@ Als u nog steeds hulp nodig heeft via visuele instructies, gebruik [deze](https:
 ## Chatrooms
 
 - **Matrix.org:** #free-rms:matrix.org
-- **IRC:** #free-rms at chat.freenode.net
+- **IRC:** #freerms at irc.libera.chat
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms

--- a/README_PL.md
+++ b/README_PL.md
@@ -37,6 +37,6 @@ lub wyślij podpisany email na adres [signrms@prog.cf](mailto:signrms@prog.cf) b
 ## Pokoje chatowe
 
 - **Matrix.org:** #free-rms:matrix.org
-- **IRC:** #free-rms at chat.freenode.net
+- **IRC:** #freerms at irc.libera.chat
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms

--- a/README_PT_BR.md
+++ b/README_PT_BR.md
@@ -35,6 +35,6 @@ ou enviar um patch assinado para [signrms@prog.cf] (mailto: signrms@prog.cf) ou 
 ## Salas de chat
 
 - **Matrix.org:** # free-rms: matrix.org
-- **IRC:** # free-rms em chat.freenode.net
+- **IRC:** # freerms em irc.libera.chat
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms 

--- a/README_PT_PT.md
+++ b/README_PT_PT.md
@@ -35,6 +35,6 @@ ou enviar um patch assinado para [signrms@prog.cf](mailto:signrms@prog.cf) or [~
 ## Salas de chat
 
 - **Matrix.org:** #free-rms:matrix.org
-- **IRC:** #free-rms at chat.freenode.net
+- **IRC:** #freerms at irc.libera.chat
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms

--- a/README_RS.md
+++ b/README_RS.md
@@ -35,6 +35,6 @@ link: https://github.com/petar_petrovic
 ## Чет
 
 - **Matrix.org:** #free-rms:matrix.org
-- **IRC:** #free-rms at chat.freenode.net
+- **IRC:** #freerms at irc.libera.chat
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms

--- a/README_RU.md
+++ b/README_RU.md
@@ -36,7 +36,6 @@ link: https://example.com/
 
 - **Matrix:** [+free-rms:matrix.org](https://matrix.to/#/+free-rms:matrix.org)
 - **IRC:** #freerms на [libera](https://libera.chat) ([webchat](https://kiwiirc.com/client/irc.libera.chat/#freerms))
-- **IRC:** #free-rms на [freenode](https://freenode.net) ([webchat](https://kiwiirc.com/client/irc.freenode.net/#free-rms), мост на Jabber: `#free-rms%chat.freenode.net@biboumi.marc-o.win`)
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms
 

--- a/README_SE.md
+++ b/README_SE.md
@@ -38,7 +38,7 @@ Om du fortfarande behöver hjälp via visuella instruktioner, använd [den här 
 ## Chattrum (på engelska)
 
 - **Matrix:** [+free-rms:matrix.org](https://matrix.to/#/+free-rms:matrix.org)
-- **IRC:** #free-rms on [freenode](https://freenode.net)
+- **IRC:** #freerms on [libera](https://libera.chat)
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms
 

--- a/README_TL.md
+++ b/README_TL.md
@@ -38,7 +38,7 @@ Puwede mong ipakita ang iyong intensyon dito: https://github.com/rms-support-let
 ## Mga silid pang-usap
 
 - **Matrix:** [+free-rms:matrix.org](https://matrix.to/#/+free-rms:matrix.org)
-- **IRC:** #free-rms sa [freenode](https://freenode.net) ([usap-sapot](http://kiwiirc.com/client/irc.freenode.net/#free-rms), gateway pang-Jabber: `#free-rms%chat.freenode.net@biboumi.marc-o.win`) at #freerms sa [libera](http://libera.chat/) ([usap-sapot](http://kiwiirc.com/client/irc.libera.chat/#freerms))
+- **IRC:** #freerms sa [libera](http://libera.chat/) ([usap-sapot](http://kiwiirc.com/client/irc.libera.chat/#freerms))
 - **XMPP/jabber:** support-rms@conf.marc-o.win
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms

--- a/README_TR.md
+++ b/README_TR.md
@@ -36,7 +36,7 @@ Eğer hala anlamadıysanız ve illaki görsel yardım istiyorum diyorsanız, [ş
 ## Sohber Odaları
 
 - **Matrix:** [+free-rms:matrix.org](https://matrix.to/#/+free-rms:matrix.org)
-- **IRC:** #free-rms on [freenode](https://freenode.net)
+- **IRC:** #freerms on [libera](https://libera.chat)
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms
 

--- a/README_UA.md
+++ b/README_UA.md
@@ -33,7 +33,7 @@ link: https://github.com/example
 ## Чатруми
 
 - **Matrix:** [+free-rms:matrix.org](https://matrix.to/#/+free-rms:matrix.org)
-- **IRC:** #free-rms на [freenode](https://freenode.net) ([webchat](https://kiwiirc.com/client/irc.freenode.net/#free-rms)) (Jabber gateway : #free-rms%chat.freenode.net@biboumi.marc-o.win )
+- **IRC:** #freerms на [libera](https://libera.chat) ([webchat](https://kiwiirc.com/client/irc.libera.chat/#freerms))
 - **XMPP/jabber:** support-rms@conf.marc-o.win
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms

--- a/README_VI.md
+++ b/README_VI.md
@@ -43,7 +43,7 @@ Nếu bạn cần hỗ trợ bằng hướng dẫn trực quan, xem [video này]
 ## Phòng chat
 
 - **Matrix:** [#free-rms:matrix.org][matrix]
-- **IRC:** #free-rms trên [freenode]
+- **IRC:** #free-rms trên [libera]
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms
 
@@ -53,4 +53,4 @@ Nếu bạn cần hỗ trợ bằng hướng dẫn trực quan, xem [video này]
 [srht]: mailto:~tyil/rms-support@lists.sr.ht
 [yt]: https://invidious.snopyta.org/watch?v=1lz5S5oS8CU
 [matrix]: https://matrix.to/#/#free-rms:matrix.org
-[freenode]: https://freenode.net
+[libera]: https://libera.chat

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -38,6 +38,6 @@ link: https://github.com/example_username
 ## 聊天室
 
 - **Matrix.org:** #free-rms:matrix.org
-- **IRC:** #free-rms at chat.freenode.net
+- **IRC:** #freerms at irc.libera.chat
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms

--- a/README_ZH-TW.md
+++ b/README_ZH-TW.md
@@ -38,6 +38,6 @@ link: https://github.com/example_username
 ## 聊天室
 
 - **Matrix.org:** #free-rms:matrix.org
-- **IRC:** #free-rms at chat.freenode.net
+- **IRC:** #freerms at irc.libera.chat
 - **Discord:** https://discord.gg/7FWkxG4CsU
 - **Telegram:** https://t.me/free_rms


### PR DESCRIPTION
New freenode management has hijacked our channel in freenode, even though we have been clear that we will stay neutral from this mess and accommodate users on both networks. But alas, freenode has now shown that they can't be trusted. I propose we complete this unfortunate migration to libera.chat.